### PR TITLE
Introduce RFC as a Technical Standard to Manage Change

### DIFF
--- a/rfc-002-using-rfcs.md
+++ b/rfc-002-using-rfcs.md
@@ -1,0 +1,27 @@
+---
+status: proposed
+---
+
+# Must Use RFCs for Architectural or Process or Technical Operational Changes
+
+## Summary
+All changes to our current architecture, processes, or ways of working must be covered by a Request for Change (RFC) for better governance and audit purposes.
+
+## Problem
+At the implementation of our initial Hack-It restructure, one of the decisions made was to eliminate the use of the Change Advisory Board (CAB) as it was felt that this was no longer fit for purpose.  The majority of our projects were in a more agile format with delivery occuring once or more per week.
+
+At the start of the Modern Tools for Housing programme, Architecture Decision Records (ADRs) were used to record decisions on changes to the architecture being built [ADR Repository](https://github.com/LBHackney-IT/lbh-adrs).  These have not been used since the base API Platform architecture was established so for much of the changes since then, there was not a consistent way of recording decisions on changes so no clear audit trail.
+
+
+## Proposal
+In order to establish a clear audit trail and decision log for changes to what we build or how we build a record of decisions must be re-introduced.  This is to be in the form of a Request for Change (RFC) which would give a broader scope on the types of change that could be recorded.
+Any change to architecture patterns, engineering processes or technical ways of working should be backed by an RFC.  The template RFC can be found at [RFC Template](https://github.com/LBHackney-IT/lbh-rfcs/blob/main/rfc-000-template.md).
+
+## Scope
+- Changes to architecture such as database technologies, encryption methods, etc.
+- Changes to programming patterns such as Event Driven Architecture
+- Changes to a feature or implementation for a serfice that has moved from development to BAU.
+
+## Out of Scope
+- Products under active development and not in BAU (unless the change relates to the overall architecture or change in development standard).
+- Emergency fixes (a retrospective RFC can be provided in these cases)


### PR DESCRIPTION
## Introducing the RFC Standard
This is an RFC to introduce RFCs.  At the moment we do not have a consistent way of recording decisions on Architecture (we previously used ADRs bit it feels limited in scope and doesn't cover all our scenarios), Processes or Technical Operations.

Use of RFCs will aid in recording and auditing decisions on changes to our architecture and technical ways of working including comments and contributions from colleagues.

Below is a preview of what the document currently looks like.  This is likely to change a bit before we have the final version.


<img width="907" alt="image" src="https://github.com/user-attachments/assets/77725bd5-f6e4-4847-a408-fb97930c8002" />
