### PR TITLE
Remove superfluous status metadata

### DIFF
--- a/rfc-000-template.md
+++ b/rfc-000-template.md
@@ -1,7 +1,3 @@
----
-status: proposed
----
-
 # My RFC Title
 
 ## Summary

--- a/rfc-001-cypress.md
+++ b/rfc-001-cypress.md
@@ -1,7 +1,3 @@
----
-status: proposed
----
-
 # Don't use Cypress Cloud
 
 ## Summary


### PR DESCRIPTION
This repository was copied and adapted from the GDS/GOV.UK one, where they handle lots of RFCs and some complexity we don't currently have.

The status metadata is confusing in its current state, where things end up in the main branch with 'proposed' even though they're accepted, and it's not much better to set it as accepted in the branch (as it isn't until it's been merged).

Rather than overlaying multiple ways to track status, this PR removes the status metadata so we determine status with:

> 1. If it's in the main branch, it's accepted.
> 2. If it's in a PR, it's proposed
> 3. Anything else is draft